### PR TITLE
Fix number inputs for additional zone setpoints

### DIFF
--- a/custom_components/daikin_ha_ekrhh_modbus/const.py
+++ b/custom_components/daikin_ha_ekrhh_modbus/const.py
@@ -154,8 +154,8 @@ DAIKIN_NUMBER_TYPES = [
 ]
 
 DAIKIN_ADDITIONAL_ZONE_NUMBER_TYPES = [
-    ["Leaving water Add Heating setpoint","leave_water_heating_setpoint", 62, "u16", {"min": 12, "max": 65, "step": 1, "unit": "°C"}],
-    ["Leaving water Add Cooling setpoint","leave_water_cooling_setpoint", 63, "u16", {"min": 5, "max": 30, "step": 1, "unit": "°C"}],
+    ["Leaving water Add Heating setpoint","Leaving_water_Add_Heating_setpoint", 62, "u16", {"min": 12, "max": 65, "step": 1, "unit": "°C"}],
+    ["Leaving water Add Cooling setpoint","Leaving_water_Add_Cooling_setpoint", 63, "u16", {"min": 5, "max": 30, "step": 1, "unit": "°C"}],
     ["Weather dependent mode Add LWT Heating setpoint offset", "Weather_dependent_mode_Add_LWT_Heating_setpoint_offset", 65, "i16", {"min": -10, "max": 10, "step": 1, "unit": "°C"}],
     ["Weather dependent mode Add LWT Cooling setpoint offset", "Weather_dependent_mode_Add_LWT_Cooling_setpoint_offset", 66, "i16", {"min": -10, "max": 10, "step": 1, "unit": "°C"}],
 ]


### PR DESCRIPTION
The number inputs for the additional zone are currently not created properly. Instead, an error message appears in the logs:

> Platform daikin_ha_ekrhh_modbus does not generate unique IDs. ID daikin_ekrhh_leave_water_heating_setpoint already exists - ignoring number.daikin_ekrhh_leaving_water_main_heating_setpoint.
> Platform daikin_ha_ekrhh_modbus does not generate unique IDs. ID daikin_ekrhh_leave_water_cooling_setpoint already exists - ignoring number.daikin_ekrhh_leaving_water_main_cooling_setpoint

Suggested and tested fix: Match the ID of the additional zone inputs to the ID created in __init__. After a restart, the number inputs number.daikin_ekrhh_leaving_water_add_heating_setpoint and number.daikin_ekrhh_leaving_water_add_cooling_setpoint are created with the expected values.

